### PR TITLE
Load observations when tab opens

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -338,6 +338,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             observationsTab.style.display = 'block';
             analysisTabBtn.classList.remove('active');
             observationsTabBtn.classList.add('active');
+            loadObservations();
         }
     };
 
@@ -389,8 +390,5 @@ document.addEventListener('DOMContentLoaded', async () => {
     useGeolocationBtn.addEventListener('click', handleGeolocationSearch);
     addressInput.addEventListener('keypress', (e) => e.key === 'Enter' && handleAddressSearch());
     analysisTabBtn.addEventListener('click', () => switchTab('analysis'));
-    observationsTabBtn.addEventListener('click', () => {
-        switchTab('observations');
-        loadObservations();
-    });
+    observationsTabBtn.addEventListener('click', () => switchTab('observations'));
 });


### PR DESCRIPTION
## Summary
- automatically fetch local observations when activating the *Observations locales* tab
- simplify tab button handler

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b08ce59d4832c90cbf38616cad990