### PR TITLE
Fix satellite basemap in both maps

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -100,11 +100,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
     
         const satelliteMap = L.tileLayer(
-            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            'https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',
             {
-                attribution:
-                    'Tiles © Esri — Source: Esri, Earthstar Geographics, and the GIS User Community',
-                maxZoom: 19,
+                attribution: '© Google',
+                maxZoom: 20,
                 crossOrigin: true
             }
         );
@@ -350,11 +349,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         });
 
         const satelliteMap = L.tileLayer(
-            'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+            'https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}',
             {
-                attribution:
-                    'Tiles © Esri — Source: Esri, Earthstar Geographics, and the GIS User Community',
-                maxZoom: 19,
+                attribution: '© Google',
+                maxZoom: 20,
                 crossOrigin: true
             }
         );


### PR DESCRIPTION
## Summary
- switch satellite tile provider to Google maps for both the analysis and observation maps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d5e2796bc832ca9c98ab19b4c4e0e