### PR TITLE
Add manual location selection on observations map

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,13 @@
         </div>
 
         <div id="observations-tab" class="tab-content" style="display:none;">
+            <div class="search-controls">
+                <div class="search-group">
+                    <button id="obs-geoloc-btn" class="action-button">Utiliser ma position actuelle</button>
+                </div>
+            </div>
             <div id="obs-status" class="status-container"></div>
-            <div id="observations-map" style="display:none;"></div>
+            <div id="observations-map"></div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- add geolocation button and map loaded initially in Observations tab
- allow double-click or long-press on map to load observations for that location

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685d5ef208c4832c83e80235956edd96