### PR TITLE
Add species labels on patrimonial map

### DIFF
--- a/biblio-patri.js
+++ b/biblio-patri.js
@@ -236,7 +236,10 @@ document.addEventListener('DOMContentLoaded', async () => {
                 popupContent += `<li><span class="legend-color" style="background-color:${s.color};"></span><i>${s.name}</i></li>`;
             });
             popupContent += '</ul></div>';
-            const marker = L.marker([location.lat, location.lon], { icon }).bindPopup(popupContent);
+            const tooltipHtml = `<i>${filtered.map(s => s.name).join('<br>')}</i>`;
+            const marker = L.marker([location.lat, location.lon], { icon })
+                .bindPopup(popupContent)
+                .bindTooltip(tooltipHtml, { permanent: true, direction: 'right', offset: [8, 0] });
             patrimonialLayerGroup.addLayer(marker);
             if (typeof proj4 !== 'undefined') {
                 const coords2154 = proj4('EPSG:4326', 'EPSG:2154', [location.lon, location.lat]);


### PR DESCRIPTION
## Summary
- show species name(s) as permanent tooltips next to patrimonial locations

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d65a3b6dc832c8bc250c527105b38