### PR TITLE
Add polygon search option

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,10 @@
                 <div class="search-group">
                     <button id="select-on-map-btn" class="action-button">Choisir sur la carte</button>
                 </div>
+                <div class="separator">ou</div>
+                <div class="search-group">
+                    <button id="draw-polygon-btn" class="action-button">Dessiner une zone</button>
+                </div>
             </div>
 
             <div id="status" class="status-container"></div>
@@ -53,6 +57,10 @@
             <div class="search-controls">
                 <div class="search-group">
                     <button id="obs-geoloc-btn" class="action-button">Utiliser ma position actuelle</button>
+                </div>
+                <div class="separator">ou</div>
+                <div class="search-group">
+                    <button id="obs-draw-polygon-btn" class="action-button">Dessiner une zone</button>
                 </div>
             </div>
             <div id="obs-status" class="status-container"></div>


### PR DESCRIPTION
## Summary
- allow drawing polygons on the analysis and observation maps
- adjust analysis pipeline to handle polygon WKT
- draw polygon or circle depending on search
- provide buttons to trigger polygon drawing on both tabs

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685d680b97a8832ca3ff1236a177ef8d