### PR TITLE
Display user location on map

### DIFF
--- a/style.css
+++ b/style.css
@@ -145,6 +145,10 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
   vertical-align: middle;
 }
 
+.user-location-icon {
+  font-size: 1.4rem;
+}
+
 @media (min-width: 600px) {
   .search-controls { flex-direction: row; flex-wrap: wrap; align-items: center; }
   .main-content { padding: 2rem; }


### PR DESCRIPTION
## Summary
- highlight current user location with a star icon
- start a geolocation watch when any map is shown
- follow the user position on both analysis and observation maps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d7e9f3e98832ca5fe5c6864c09e94