### PR TITLE
Adjust map label background transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -151,6 +151,12 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
   vertical-align: middle;
 }
 
+/* Slightly transparent background for marker labels */
+.leaflet-tooltip {
+  background-color: rgba(255, 255, 255, 0.8);
+  border-color: rgba(255, 255, 255, 0.8);
+}
+
 @media (min-width: 600px) {
   .search-controls { flex-direction: row; flex-wrap: wrap; align-items: center; }
   .main-content { padding: 2rem; }


### PR DESCRIPTION
## Summary
- reduce opacity of Leaflet tooltips so the map is more visible

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e3ee1bfe4832cbae1045c5a87992b