### PR TITLE
Adjust map label transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -165,3 +165,9 @@ html[data-theme="dark"] tbody tr:hover { background-color: rgba(198,40,40,0.15);
     border-radius: 0;
   }
 }
+
+/* Slightly transparent background for permanent map labels */
+.leaflet-tooltip {
+  background-color: rgba(255, 255, 255, 0.75) !important;
+  border: 1px solid rgba(255, 255, 255, 0.75) !important;
+}


### PR DESCRIPTION
## Summary
- tweak the background of Leaflet tooltips so map labels don't obscure the maps

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_685e41aaa3d8832cbd77fb791f06fdbe