### PR TITLE
Adjust tooltip backgrounds

### DIFF
--- a/style.css
+++ b/style.css
@@ -127,6 +127,16 @@ th, td {
   vertical-align: middle;
 }
 
+/* Partially transparent background for Leaflet tooltips */
+.leaflet-tooltip {
+  background-color: rgba(255, 255, 255, 0.8);
+  border: 1px solid var(--border);
+}
+html[data-theme="dark"] .leaflet-tooltip {
+  background-color: rgba(38, 43, 47, 0.8);
+  border-color: var(--border);
+}
+
 .user-location-icon {
   font-size: 1.4rem;
   color: #2e7d32;


### PR DESCRIPTION
## Summary
- adjust tooltip background to be semi-transparent for better readability

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e573bd504832ca3c60416cfecb176