### PR TITLE
Add dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="theme-color" content="#c62828">
+    <meta name="theme-color" content="#181a1b">
     <meta name="mobile-web-app-capable" content="yes">
     <title>Analyse Patrimoniale de la Flore</title>
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌿</text></svg>">
@@ -24,6 +24,7 @@
         <div class="tabs">
             <button id="analysis-tab-btn" class="tab-button active">Analyse patrimoniale</button>
             <button id="observations-tab-btn" class="tab-button">Observations locales</button>
+            <button id="theme-toggle" class="tab-button" title="Changer de thème">☀️</button>
         </div>
         
         <div id="analysis-tab" class="tab-content" style="display:block;">

--- a/style.css
+++ b/style.css
@@ -41,9 +41,9 @@ h1 {
 
 .tabs {
   display: flex;
-  justify-content: center;
   gap: 0.75rem;
   margin-bottom: 1rem;
+  align-items: center;
 }
 .tab-button {
   background: var(--card);
@@ -56,6 +56,10 @@ h1 {
 .tab-button.active {
   background: var(--primary);
   color: #fff;
+}
+
+#theme-toggle {
+  margin-left: auto;
 }
 
 .tab-content {

--- a/ui.js
+++ b/ui.js
@@ -12,6 +12,21 @@
         const notificationContainer = document.createElement('div');
         notificationContainer.id = 'notification-container';
         document.body.appendChild(notificationContainer);
+
+        const savedTheme = localStorage.getItem('theme') || 'dark';
+        document.documentElement.setAttribute('data-theme', savedTheme);
+
+        const toggleBtn = document.getElementById('theme-toggle');
+        if (toggleBtn) {
+            toggleBtn.textContent = savedTheme === 'dark' ? '☀️' : '🌙';
+            toggleBtn.addEventListener('click', () => {
+                const current = document.documentElement.getAttribute('data-theme');
+                const next = current === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', next);
+                localStorage.setItem('theme', next);
+                toggleBtn.textContent = next === 'dark' ? '☀️' : '🌙';
+            });
+        }
     });
 
     window.showNotification = function(message, type = 'info') {


### PR DESCRIPTION
## Summary
- set default theme to dark
- add theme toggle button in tabs
- style theme toggle button
- implement theme switch logic in `ui.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685ebfe43774832c928774a2cf783a71